### PR TITLE
Async up

### DIFF
--- a/ipfs-to-cf-images/async_lib.py
+++ b/ipfs-to-cf-images/async_lib.py
@@ -4,7 +4,7 @@ import asyncio
 async def dispatch(runner):
     queue = asyncio.Queue()
     await runner(queue)
-    limited_set = LimitedSet(maxsize=5, jozo= queue)
+    limited_set = LimitedSet(maxsize=20, jozo= queue)
 
     try:
         while not queue.empty():

--- a/ipfs-to-cf-images/main.py
+++ b/ipfs-to-cf-images/main.py
@@ -36,7 +36,6 @@ def init():
 async def async_init(jozo):
   for i in range(START_AT, START_AT + OFFSET):
     with open(f'missing/chunk{i}.json') as f:
-      info(f'[ASYNC INIT]: 🎲 Starting at {i} of {START_AT + OFFSET}')
       meta = load(f)
     info(f'[ASYNC INIT]: 🎲 Starting at {i} of {START_AT + OFFSET}')
     # mapped = list(map(map_fetch_one, meta))

--- a/ipfs-to-cf-images/main.py
+++ b/ipfs-to-cf-images/main.py
@@ -33,15 +33,16 @@ def init():
       store_to_durable_object(final)
       info(f'[CHUNK]: ✅ {i}')
 
-async def async_init():
+async def async_init(jozo):
   for i in range(START_AT, START_AT + OFFSET):
     with open(f'missing/chunk{i}.json') as f:
       info(f'[ASYNC INIT]: 🎲 Starting at {i} of {START_AT + OFFSET}')
       meta = load(f)
-      # mapped = list(map(map_fetch_one, meta))
-      for item in meta:
-        await add_task(map_fetch_one(item))
-      # await add_to_queue(list(map(map_fetch_one, meta)))
+    info(f'[ASYNC INIT]: 🎲 Starting at {i} of {START_AT + OFFSET}')
+    # mapped = list(map(map_fetch_one, meta))
+    for item in meta:
+        await add_task(map_fetch_one(item), jozo)
+    # await add_to_queue(list(map(map_fetch_one, meta)))
 
   
 

--- a/ipfs-to-cf-images/my_queue.py
+++ b/ipfs-to-cf-images/my_queue.py
@@ -1,11 +1,9 @@
 
-from asyncio import Queue
+Jozo = None
 
-jozo = Queue()
-
-async def add_to_queue(tasks):
-  for task in tasks:
-      await jozo.put(task)
-
-async def add_task(task):
-  await jozo.put(task)
+async def add_task(task, jozo = None):
+    global Jozo
+    assert jozo is not None or Jozo is not None
+    Jozo = Jozo or jozo
+    jozo = jozo or Jozo
+    await jozo.put(task)


### PR DESCRIPTION
the PoC for async task dispatching was updated with using proper synchronisation primitives to solve deadlocking. 

Check the removed commend - async_lib.py:34, but the code calls `LimitedSet.add` from multiple tasks