### PR TITLE
🔧 query from ci runner

### DIFF
--- a/minimal-cf-images/constants.py
+++ b/minimal-cf-images/constants.py
@@ -1,5 +1,5 @@
 CF_DURABLE_OBJECT = "https://durable-jpeg.kodadot.workers.dev"
-SUBSQUID_API = 'https://app.gc.subsquid.io/beta/rubick/007/graphql'
+SUBSQUID_API = "https://app.gc.subsquid.io/beta/rubick/007/graphql"
 
 PINATA_BASE_API = "https://kodadot.mypinata.cloud/"
 IPFS_PREFIX = "ipfs://"

--- a/minimal-cf-images/graphql.py
+++ b/minimal-cf-images/graphql.py
@@ -1,7 +1,7 @@
 from datelib import graphql_ago
 
 
-LAST_MINTED_QUERY = "query lastMinted($ago: DateTime) {\n  nFTEntities(orderBy: blockNumber_DESC, where: { createdAt_gte: $ago }) {\n    createdAt\n    meta {\n      id\n      image\n      animationUrl\n    }\n  }\n}"
+LAST_MINTED_QUERY = "query lastMinted($ago: DateTime) {\n  nftEntities(orderBy: blockNumber_DESC, where: { createdAt_gte: $ago }) {\n    createdAt\n    meta {\n      id\n      image\n      animationUrl\n    }\n  }\n}"
 
 def last_minted_query():
   return {


### PR DESCRIPTION
I don't know where `minimal-cf-images` is used but this closes #11 

`nFTEntities` =/= `nftEntities`